### PR TITLE
refactor: deadReduxTests, move constants out of action creator file

### DIFF
--- a/browser/redux/dead/action-creator.js
+++ b/browser/redux/dead/action-creator.js
@@ -1,5 +1,4 @@
-export const KILL_PLAYER = 'KILL_PLAYER';
-export const REVIVE_PLAYER = 'REVIVE_PLAYER';
+import { KILL_PLAYER, REVIVE_PLAYER } from './constants';
 
 export const killPlayer = () => ({ type: KILL_PLAYER });
 

--- a/browser/redux/dead/constants.js
+++ b/browser/redux/dead/constants.js
@@ -1,0 +1,2 @@
+export const KILL_PLAYER = 'KILL_PLAYER';
+export const REVIVE_PLAYER = 'REVIVE_PLAYER';

--- a/browser/redux/dead/reducer.js
+++ b/browser/redux/dead/reducer.js
@@ -1,4 +1,4 @@
-import { KILL_PLAYER, REVIVE_PLAYER } from './action-creator.js';
+import { KILL_PLAYER, REVIVE_PLAYER } from './constants';
 
 export const dead = (state = false, action) => {
   switch (action.type) {

--- a/tests/browser/deadRedux.test.js
+++ b/tests/browser/deadRedux.test.js
@@ -1,61 +1,46 @@
-'use strict'
-
-import { createStore } from 'redux'
-import { expect } from 'chai'
-import { 
-					KILL_PLAYER, 
-					REVIVE_PLAYER, 
-					killPlayer, 
-					revivePlayer 
-				} from '../../browser/redux/dead/action-creator'
-import { dead } from '../../browser/redux/dead/reducer'
+import { createStore } from 'redux';
+import { expect } from 'chai';
+import { KILL_PLAYER, REVIVE_PLAYER } from '../../browser/redux/dead/constants';
+import { killPlayer, revivePlayer } from '../../browser/redux/dead/action-creator';
+import { dead } from '../../browser/redux/dead/reducer';
 
 describe('Front end dead action creator', () => {
   describe('killPlayer', () => {
     it('returns expected action description', () => {
-      const expectedAction = {
-        type: KILL_PLAYER
-      }
-      expect(killPlayer()).to.be.deep.equal(expectedAction)
-    })
-  })
+      const expectedAction = { type: KILL_PLAYER };
+      expect(killPlayer()).to.be.deep.equal(expectedAction);
+    });
+  });
+
   describe('revivePlayer', () => {
     it('returns expected action description', () => {
-      const expectedAction = {
-        type: REVIVE_PLAYER
-      }
-
-      expect(revivePlayer()).to.be.deep.equal(expectedAction)
-    })
-  })
-})
+      const expectedAction = { type: REVIVE_PLAYER };
+      expect(revivePlayer()).to.be.deep.equal(expectedAction);
+    });
+  });
+});
 
 describe('Front end dead reducer', () => {
   let testStore;
   beforeEach('Create testing store from reducer', () => {
     testStore = createStore(dead);
-  })
+  });
+
   it('has an initial state of an false', () => {
     expect(testStore.getState()).to.be.deep.equal(false);
-  })
+  });
 
   describe('KILL_PLAYER', () => {
     it('sets player death to true', () => {
-      
-      testStore.dispatch({
-        type: KILL_PLAYER
-      })
-      expect(testStore.getState()).to.be.deep.equal(true)
-    })
-  })
+      testStore.dispatch({ type: KILL_PLAYER });
+      expect(testStore.getState()).to.be.deep.equal(true);
+    });
+  });
 
   describe('REVIVE_PLAYER', () => {
     it('sets player death to false', () => {
-      
-      testStore.dispatch({
-        type: REVIVE_PLAYER
-      })
-      expect(testStore.getState()).to.be.deep.equal(false)
-    })
-  })
-})
+      testStore.dispatch({ type: REVIVE_PLAYER });
+      expect(testStore.getState()).to.be.deep.equal(false);
+    });
+  });
+});


### PR DESCRIPTION
Moved constants out of action creator file. Adjusted import and exports for tests, reducer, and action creator files. Style adjustment to tests. Fixes issue #205 